### PR TITLE
add habitat plugin to plugin installations

### DIFF
--- a/default.toml
+++ b/default.toml
@@ -47,5 +47,6 @@ plugins = [
   "rich-text-publisher-plugin",
   "console-column-plugin",
   "docker-plugin",
-  "blueocean"
+  "blueocean",
+  "habitat"
 ]


### PR DESCRIPTION
Adds support for installation of the habitat Jenkins plugin. 💪 

Signed-off-by: skylerto <skylerclayne@gmail.com>